### PR TITLE
remove prettier rule and rulesDirectory fields

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,8 +6,6 @@
   "rules": {
     "interface-name": [true, "never-prefix"],
     "member-access": [true, "no-public"],
-    "ordered-imports": false,
-    "prettier": true
-  },
-  "rulesDirectory": ["tslint-plugin-prettier"]
+    "ordered-imports": false
+  }
 }


### PR DESCRIPTION
I don't think we need this, since we want to run prettier separately from tslint.